### PR TITLE
Command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ local.properties
 /build/
 /.gradle/
 *.swp
+dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ This library will tag JPEG images with the Exif/XMP tags standard for Proven ver
 
 Ubuntu prerequisites:
 `apt-get install maven exiftool`
+
+## Command line
+The Maven packaging is configured to build a [shaded JAR](https://maven.apache.org/plugins/maven-shade-plugin/usage.html) which contains all of the dependencies, which makes it large.
+`mvn package
+java -cp target/provenj-0.0.1.jar provenj.CmdLine IMG_0001.jpeg -DGUID=7e26a501-30fb-4775-a494-c42691dc21e9 -DBitcoinBlockNumber=10101 -DFileName=MemePic.jpg`
+All options are optional.
+It returns a path to the temporary directory of the enclosure.

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile group: 'com.adobe.xmp', name: 'xmpcore', version: '6.1.10'
     compile group: 'com.j2html', name: 'j2html', version: '0.7'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
+    compile group: 'com.google.guava', name: 'guava', version: '20.0'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     compile group: 'com.adobe.xmp', name: 'xmpcore', version: '6.1.10'
     compile group: 'com.j2html', name: 'j2html', version: '0.7'
+    compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,11 @@ project.ext {
     junitVersion = '4.12'
 }
 
+jar {
+    manifest {
+        from('src/main/java/META-INF/MANIFEST.MF')
+    }
+}
 dependencies {
     testCompile 'info.cukes:cucumber-java:' + cucumberVersion
     testCompile 'info.cukes:cucumber-junit:' + cucumberVersion
@@ -14,7 +19,7 @@ dependencies {
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     compile group: 'com.adobe.xmp', name: 'xmpcore', version: '6.1.10'
     compile group: 'com.j2html', name: 'j2html', version: '0.7'
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
+    compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'
     compile group: 'com.google.guava', name: 'guava', version: '20.0'
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -73,6 +73,36 @@
                     <target>${java.version}</target>
                     <compilerArgument>-Werror</compilerArgument>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>src/main/java/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>j2html</artifactId>
             <version>0.7</version>
         </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: provenj.CmdLine
+

--- a/src/main/java/provenj/CmdLine.java
+++ b/src/main/java/provenj/CmdLine.java
@@ -9,10 +9,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
-import java.security.NoSuchAlgorithmException;
 
 // Command-line interface for Provenj
 public class CmdLine {
@@ -41,21 +38,9 @@ public class CmdLine {
             metadata = enclosure.fillEnclosure(Paths.get(args[0]),metadata);
             System.out.println(enclosure.getPath());
         }
-        catch( ParseException exp ) {
+        catch( Exception e ) {
             // oops, something went wrong
-            System.err.println( "Parsing failed. Reason: " + exp.getMessage() );
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        } catch (XMPException e) {
-            e.printStackTrace();
+            System.err.println("Parsing failed. Reason: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/provenj/CmdLine.java
+++ b/src/main/java/provenj/CmdLine.java
@@ -1,11 +1,18 @@
 package provenj;
 
+import com.adobe.internal.xmp.XMPException;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 
 // Command-line interface for Provenj
 public class CmdLine {
@@ -19,14 +26,36 @@ public class CmdLine {
                 .build());
 
         try {
+
+            if (args.length < 1) throw new ParseException("You must at least provide the path to the file.");
+
             // parse the command line arguments
             CommandLine line = parser.parse( options, args );
 
-            System.out.println(line.toString());
+            Metadata metadata = new Metadata();
+            for(int i = 0; i < 2*line.getOptions().length; i += 2) {
+                metadata.setByTag(line.getOptionValues("D")[i],line.getOptionValues("D")[i+1]);
+            }
+
+            Enclosure enclosure = new Enclosure();
+            metadata = enclosure.fillEnclosure(Paths.get(args[0]),metadata);
+            System.out.println(enclosure.getPath());
         }
         catch( ParseException exp ) {
             // oops, something went wrong
-            System.err.println( "Parsing failed.  Reason: " + exp.getMessage() );
+            System.err.println( "Parsing failed. Reason: " + exp.getMessage() );
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } catch (XMPException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/provenj/CmdLine.java
+++ b/src/main/java/provenj/CmdLine.java
@@ -12,6 +12,7 @@ import org.apache.commons.cli.ParseException;
 import java.nio.file.Paths;
 
 // Command-line interface for Provenj
+@SuppressWarnings("unchecked")
 public class CmdLine {
     public static void main( String[] args ) {
         // create the parser

--- a/src/main/java/provenj/CmdLine.java
+++ b/src/main/java/provenj/CmdLine.java
@@ -1,8 +1,32 @@
 package provenj;
 
-/**
- * Created by cleduc on 09/12/16.
- */
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 
+// Command-line interface for Provenj
 public class CmdLine {
+    public static void main( String[] args ) {
+        // create the parser
+        CommandLineParser parser = new DefaultParser();
+        Options options = new Options();
+        options.addOption(Option.builder("D")
+                .hasArgs()
+                .valueSeparator('=')
+                .build());
+
+        try {
+            // parse the command line arguments
+            CommandLine line = parser.parse( options, args );
+
+            System.out.println(line.toString());
+        }
+        catch( ParseException exp ) {
+            // oops, something went wrong
+            System.err.println( "Parsing failed.  Reason: " + exp.getMessage() );
+        }
+    }
 }

--- a/src/main/java/provenj/CmdLine.java
+++ b/src/main/java/provenj/CmdLine.java
@@ -1,0 +1,8 @@
+package provenj;
+
+/**
+ * Created by cleduc on 09/12/16.
+ */
+
+public class CmdLine {
+}

--- a/src/main/java/provenj/ImageTagger.java
+++ b/src/main/java/provenj/ImageTagger.java
@@ -4,6 +4,7 @@ import com.adobe.internal.xmp.XMPMeta;
 import com.adobe.internal.xmp.XMPException;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.UUID;
 
 
 // Applies XMP tags to a JPEG image
@@ -21,6 +22,12 @@ public class ImageTagger extends Metadata {
         meta.setProperty(XmpUtil.PROVEN_NAMESPACE, ProvenLib.PROVEN_ETHEREUM_BLOCK_HASH,   getEthereumBlockHash());
         meta.setProperty(XmpUtil.PROVEN_NAMESPACE, ProvenLib.PROVEN_PREVIOUS_IPFS_HASH,    getPreviousIPFSHash());
         meta.setProperty(XmpUtil.PROVEN_NAMESPACE, ProvenLib.PROVEN_PREVIOUS_FILE_HASHES,  getPreviousFileHashes());
+
+        // Generate a GUID if none specified
+        if (null == getGUID()){
+            setGUID(UUID.randomUUID());
+        }
+
         meta.setProperty(XmpUtil.PROVEN_NAMESPACE, ProvenLib.PROVEN_GUID,                  getGUID().toString());
 
         XmpUtil.writeXMPMeta(inputFile, outputFile, meta);

--- a/src/main/java/provenj/Metadata.java
+++ b/src/main/java/provenj/Metadata.java
@@ -1,5 +1,7 @@
 package provenj;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.UUID;
 
 // Implements in-memory storage for metadata.
@@ -22,10 +24,12 @@ public class Metadata implements MetadataIntf {
 
     public int    getBitcoinBlockNumber() { return m_bitcoinBlockNumber; }
     public void   setBitcoinBlockNumber(int blockNumber) { m_bitcoinBlockNumber = blockNumber; }
+    public void   setBitcoinBlockNumber(String blockNumber) { m_bitcoinBlockNumber = Integer.parseInt(blockNumber); }
     public String getBitcoinBlockHash() { return m_bitcoinBlockHash; }
     public void   setBitcoinBlockHash(String blockHash) { m_bitcoinBlockHash = blockHash; }
     public int    getEthereumBlockNumber() { return m_ethereumBlockNumber; }
     public void   setEthereumBlockNumber(int blockNumber) { m_ethereumBlockNumber = blockNumber; }
+    public void   setEthereumBlockNumber(String blockNumber) { m_ethereumBlockNumber = Integer.parseInt(blockNumber); }
     public String getEthereumBlockHash() { return m_ethereumBlockHash; }
     public void   setEthereumBlockHash(String blockHash) { m_ethereumBlockHash = blockHash; }
     public String getPreviousIPFSHash() { return m_previousIPFSHash; }
@@ -38,6 +42,8 @@ public class Metadata implements MetadataIntf {
     public void   setFileHashes(String fileHashes) { m_fileHashes = fileHashes; }
     public UUID   getGUID() { return m_guid; }
     public void   setGUID(UUID guid) { m_guid = guid; }
+    public void   setGUID(String guid) { m_guid = UUID.fromString(guid); }
+
     public Metadata copy(Metadata metadata){
         setBitcoinBlockNumber(metadata.getBitcoinBlockNumber());
         setBitcoinBlockHash(metadata.getBitcoinBlockHash());
@@ -49,5 +55,10 @@ public class Metadata implements MetadataIntf {
         setFileHashes(metadata.getFileHashes());
         setGUID(metadata.getGUID());
         return this;
+    }
+
+    public void setByTag(String tagName, String value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = this.getClass().getDeclaredMethod(String.format("set%s",tagName),String.class);
+        method.invoke(this,value);
     }
 }

--- a/src/main/java/provenj/Metadata.java
+++ b/src/main/java/provenj/Metadata.java
@@ -18,6 +18,8 @@ public class Metadata implements MetadataIntf {
     protected String m_fileName;
     protected String m_fileHashes;
     public static String[] TAGS = {
+            ProvenLib.PROVEN_FILE_NAME,
+            ProvenLib.PROVEN_FILE_HASHES,
             ProvenLib.PROVEN_BITCOIN_BLOCK_NUMBER,
             ProvenLib.PROVEN_BITCOIN_BLOCK_HASH,
             ProvenLib.PROVEN_ETHEREUM_BLOCK_NUMBER,

--- a/src/main/java/provenj/Metadata.java
+++ b/src/main/java/provenj/Metadata.java
@@ -2,6 +2,8 @@ package provenj;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 // Implements in-memory storage for metadata.
@@ -15,6 +17,14 @@ public class Metadata implements MetadataIntf {
     protected UUID   m_guid;
     protected String m_fileName;
     protected String m_fileHashes;
+    public static String[] TAGS = {
+            ProvenLib.PROVEN_BITCOIN_BLOCK_NUMBER,
+            ProvenLib.PROVEN_BITCOIN_BLOCK_HASH,
+            ProvenLib.PROVEN_ETHEREUM_BLOCK_NUMBER,
+            ProvenLib.PROVEN_ETHEREUM_BLOCK_HASH,
+            ProvenLib.PROVEN_PREVIOUS_IPFS_HASH,
+            ProvenLib.PROVEN_PREVIOUS_FILE_HASHES,
+            ProvenLib.PROVEN_GUID};
 
     public Metadata(){}
 
@@ -58,6 +68,7 @@ public class Metadata implements MetadataIntf {
     }
 
     public void setByTag(String tagName, String value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        if( !Arrays.asList(TAGS).contains(tagName)) throw new NoSuchElementException();
         Method method = this.getClass().getDeclaredMethod(String.format("set%s",tagName),String.class);
         method.invoke(this,value);
     }

--- a/src/main/java/provenj/MetadataIntf.java
+++ b/src/main/java/provenj/MetadataIntf.java
@@ -1,15 +1,18 @@
 package provenj;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 
 // Metadata API for hashes from public blockchains, previous submissions, and identifiers.
 public interface MetadataIntf {
     int    getBitcoinBlockNumber();
     void   setBitcoinBlockNumber(int blockNumber);
+    void   setBitcoinBlockNumber(String blockNumber);
     String getBitcoinBlockHash();
     void   setBitcoinBlockHash(String blockHash);
     int    getEthereumBlockNumber();
     void   setEthereumBlockNumber(int blockNumber);
+    void   setEthereumBlockNumber(String blockNumber);
     String getEthereumBlockHash();
     void   setEthereumBlockHash(String blockHash);
     String getPreviousIPFSHash();
@@ -22,5 +25,7 @@ public interface MetadataIntf {
     void   setFileHashes(String fileHashes);
     UUID   getGUID();
     void   setGUID(UUID guid);
+    void   setGUID(String guid);
     Metadata copy(Metadata metadata);
+    public void setByTag(String tagName, String value) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException;
 }

--- a/src/test/java/provenj/Stepdefs.java
+++ b/src/test/java/provenj/Stepdefs.java
@@ -199,14 +199,21 @@ public class Stepdefs {
         assertEquals(fileHashes, metadata.getPreviousFileHashes());
     }
 
+    @When("^I call the command line interface with nothing$")
+    public void i_call_the_command_line_interface_with_nothing() throws Throwable {
+        String[] args = {};
+        CmdLine.main(args);
+    }
+
+    @When("^I call the command line interface with invalid metadata tags\"$")
+    public void i_call_the_command_line_interface_with_invalid_metadata_tags() throws Throwable {
+        String[] args = {"Bogus.jpeg","-DBogus=BogusValue"};
+        CmdLine.main(args);
+    }
+
     @When("^I call the command line interface with the JPEG file \"([^\"]*)\"$")
     public void i_call_the_command_line_interface_with_the_JPEG_file(String arg1) throws Throwable {
         String[] args = {arg1,String.format("-D%1$s=%2$s",ProvenLib.PROVEN_GUID,UUID.randomUUID().toString())};
         CmdLine.main(args);
-    }
-
-    @Then("^nothing bad should happen$")
-    public void nothing_bad_should_happen() throws Throwable {
-        assert(true);
     }
 }

--- a/src/test/java/provenj/Stepdefs.java
+++ b/src/test/java/provenj/Stepdefs.java
@@ -23,16 +23,24 @@ public class Stepdefs {
 
     @Given("^the Bitcoin block number (\\d+)$")
     public void the_Bitcoin_block_number(int blockNumber) throws Throwable {
+        // testing set-by-string
+        metadata.setByTag("BitcoinBlockNumber", "999");
+        assertEquals(999, metadata.getBitcoinBlockNumber());
         metadata.setBitcoinBlockNumber(blockNumber);
     }
 
     @Given("^the Bitcoin block hash \"([^\"]*)\"$")
     public void the_Bitcoin_block_hash(String blockHash) throws Throwable {
+        metadata.setByTag("BitcoinBlockHash", "hashtash");
+        assertEquals("hashtash", metadata.getBitcoinBlockHash());
         metadata.setBitcoinBlockHash(blockHash);
     }
 
     @Given("^the Ethereum block number (\\d+)$")
     public void the_Ethereum_block_number(int blockNumber) throws Throwable {
+        // testing set-by-string
+        metadata.setByTag("EthereumBlockNumber", "8888");
+        assertEquals(8888, metadata.getEthereumBlockNumber());
         metadata.setEthereumBlockNumber(blockNumber);
     }
 
@@ -53,6 +61,9 @@ public class Stepdefs {
 
     @Given("^the GUID \"([^\"]*)\"$")
     public void the_GUID(String guid) throws Throwable {
+        // testing set-by-string
+        metadata.setByTag("GUID", "1aa3ded6-7fbc-4cef-8f86-6312ea5aebaa");
+        assertEquals(UUID.fromString("1aa3ded6-7fbc-4cef-8f86-6312ea5aebaa"), metadata.getGUID());
         metadata.setGUID(UUID.fromString(guid));
     }
 

--- a/src/test/java/provenj/Stepdefs.java
+++ b/src/test/java/provenj/Stepdefs.java
@@ -67,6 +67,12 @@ public class Stepdefs {
         metadata.setGUID(UUID.fromString(guid));
     }
 
+    @Given("^the file name \"([^\"]*)\"$")
+    public void the_file_name(String fileName) throws Throwable {
+        metadata.setFileName(fileName);
+    }
+
+
     private String shellCommand(String command){
         Runtime rt = Runtime.getRuntime();
 

--- a/src/test/java/provenj/Stepdefs.java
+++ b/src/test/java/provenj/Stepdefs.java
@@ -198,4 +198,15 @@ public class Stepdefs {
         assertEquals(fileHashes, getFinalImageTag(ProvenLib.PROVEN_PREVIOUS_FILE_HASHES));
         assertEquals(fileHashes, metadata.getPreviousFileHashes());
     }
+
+    @When("^I call the command line interface with the JPEG file \"([^\"]*)\"$")
+    public void i_call_the_command_line_interface_with_the_JPEG_file(String arg1) throws Throwable {
+        String[] args = {arg1,String.format("-D%1$s=%2$s",ProvenLib.PROVEN_GUID,UUID.randomUUID().toString())};
+        CmdLine.main(args);
+    }
+
+    @Then("^nothing bad should happen$")
+    public void nothing_bad_should_happen() throws Throwable {
+        assert(true);
+    }
 }

--- a/src/test/resources/provenj/build-enclosure.feature
+++ b/src/test/resources/provenj/build-enclosure.feature
@@ -30,4 +30,11 @@ Feature: Create an enclosure which is a temporary directory that contains all as
 
   Scenario: Command line usage
     When I call the command line interface with the JPEG file "src/test/resources/provenj/2016-12-01-175915.jpg"
-    Then nothing bad should happen
+
+  Scenario: Incorrect command line usage, part one
+    When I call the command line interface with nothing
+
+  Scenario: Incorrect command line usage, part two
+    When I call the command line interface with invalid metadata tags"
+
+

--- a/src/test/resources/provenj/build-enclosure.feature
+++ b/src/test/resources/provenj/build-enclosure.feature
@@ -22,3 +22,8 @@ Feature: Create an enclosure which is a temporary directory that contains all as
     And the Ethereum block number everywhere is 2619567
     And the last IPFS file hash everywhere is "QmP1KyrSsD4KGPFRsVxV66cZ95LqhLWGbwCakzRsoKjrTu"
     And the last file hashes everywhere is "dff0c94255cd1f68a824e81005b00f617afecd74c6cccecfbae0d2b7875fabf3"
+
+  Scenario: Create another enclosure but specify a filename
+    Given the file name "DogTongue.jpeg"
+    When I provide a JPEG file "src/test/resources/provenj/2016-12-01-175915.jpg"
+    Then it should contain in the payload directory the file "DogTongue.jpeg"

--- a/src/test/resources/provenj/build-enclosure.feature
+++ b/src/test/resources/provenj/build-enclosure.feature
@@ -27,3 +27,7 @@ Feature: Create an enclosure which is a temporary directory that contains all as
     Given the file name "DogTongue.jpeg"
     When I provide a JPEG file "src/test/resources/provenj/2016-12-01-175915.jpg"
     Then it should contain in the payload directory the file "DogTongue.jpeg"
+
+  Scenario: Command line usage
+    When I call the command line interface with the JPEG file "src/test/resources/provenj/2016-12-01-175915.jpg"
+    Then nothing bad should happen


### PR DESCRIPTION
In the Maven build, create a shaded JAR file which contains all of the dependencies (turns out to be around 10M) which lets us avoid CLASSPATH fun.
Created a simple CLI that takes a file and optional tags, producing the enclosure.
Created set-by-string methods for metadata members in order to achieve the above.