### PR TITLE
use ipfs-api-kotlin instead of java-ipfs-api in order to support Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This library will tag JPEG images with the Exif/XMP tags standard for Proven ver
 An [IPFS.io](https://ipfs.io) daemon is required to be running on the local machine (for testing and for publishing to IPFS).
 
 Ubuntu prerequisites:
-`apt-get install maven exiftool`
+`apt-get install maven exiftool curl`
 
 ## Usage
 You can use this project by building the JAR with `mvn package`, or by using [JitPack](https://jitpack.io/#1AmOXsGnfXdbNg3RMTyPCHkn2aT/provenj/) (also supporting Gradle, SBT, etc).

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testCompile 'info.cukes:cucumber-junit:' + cucumberVersion
     testCompile 'junit:junit:' + junitVersion
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
-    compile group: 'com.github.celeduc', name: 'ipfs-api-kotlin', version: '0.9999'
+    compile group: 'com.github.celeduc', name: 'ipfs-api-kotlin', version: '0.99999'
     compile group: 'com.adobe.xmp', name: 'xmpcore', version: '6.1.10'
     compile group: 'com.j2html', name: 'j2html', version: '0.7'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testCompile 'info.cukes:cucumber-junit:' + cucumberVersion
     testCompile 'junit:junit:' + junitVersion
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
-    compile group: 'com.github.celeduc', name: 'ipfs-api-kotlin', version: '0.99999'
+    compile group: 'com.github.celeduc', name: 'ipfs-api-kotlin', version: '0.999999'
     compile group: 'com.adobe.xmp', name: 'xmpcore', version: '6.1.10'
     compile group: 'com.j2html', name: 'j2html', version: '0.7'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testCompile 'info.cukes:cucumber-junit:' + cucumberVersion
     testCompile 'junit:junit:' + junitVersion
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
-    compile group: 'com.github.ipfs', name: 'java-ipfs-api', version: 'v1.0.0'
+    compile group: 'com.github.celeduc', name: 'ipfs-api-kotlin', version: '0.999'
     compile group: 'com.adobe.xmp', name: 'xmpcore', version: '6.1.10'
     compile group: 'com.j2html', name: 'j2html', version: '0.7'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,20 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'jacoco'
 
+buildscript {
+  ext.kotlin_version = '1.0.6'
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+  }
+}
+
 project.ext {
     cucumberVersion = '1.2.5'
     junitVersion = '4.12'
+    kotlin_version = '1.0.6'
 }
 
 jar {
@@ -21,7 +32,7 @@ dependencies {
     testCompile 'info.cukes:cucumber-junit:' + cucumberVersion
     testCompile 'junit:junit:' + junitVersion
     compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
-    compile group: 'com.github.celeduc', name: 'ipfs-api-kotlin', version: '0.999'
+    compile group: 'com.github.celeduc', name: 'ipfs-api-kotlin', version: '0.9999'
     compile group: 'com.adobe.xmp', name: 'xmpcore', version: '6.1.10'
     compile group: 'com.j2html', name: 'j2html', version: '0.7'
     compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
             <version>0.7</version>
         </dependency>
         <dependency>
-            <groupId>com.github.ipfs</groupId>
-            <artifactId>java-ipfs-api</artifactId>
-            <version>v1.0.0</version>
+            <groupId>com.github.celeduc</groupId>
+            <artifactId>ipfs-api-kotlin</artifactId>
+            <version>0.999</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.github.celeduc</groupId>
             <artifactId>ipfs-api-kotlin</artifactId>
-            <version>0.999</version>
+            <version>0.9999</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.github.celeduc</groupId>
             <artifactId>ipfs-api-kotlin</artifactId>
-            <version>0.9999</version>
+            <version>0.99999</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.github.celeduc</groupId>
             <artifactId>ipfs-api-kotlin</artifactId>
-            <version>0.99999</version>
+            <version>0.999999</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/src/main/java/provenj/Distributor.java
+++ b/src/main/java/provenj/Distributor.java
@@ -8,6 +8,6 @@ import io.ipfs.kotlin.IPFS;
 // Distributes a file over IPFS
 public class Distributor {
     public String publishIPFS(Path path) throws IOException {
-        return new IPFS().getAdd().file(path.toFile()).getHash();
+        return new IPFS().getAdd().file(path.toFile(), path.toFile().getName()).getHash();
     }
 }

--- a/src/main/java/provenj/Distributor.java
+++ b/src/main/java/provenj/Distributor.java
@@ -3,15 +3,11 @@ package provenj;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import io.ipfs.api.IPFS;
-import io.ipfs.api.MerkleNode;
-import io.ipfs.api.NamedStreamable;
+import io.ipfs.kotlin.IPFS;
 
 // Distributes a file over IPFS
 public class Distributor {
     public String publishIPFS(Path path) throws IOException {
-        IPFS ipfs = new IPFS("/ip4/127.0.0.1/tcp/5001");
-        MerkleNode addResult = ipfs.add(new NamedStreamable.FileWrapper(path.toFile()));
-        return (addResult.hash.toString());
+        return new IPFS().getAdd().file(path.toFile()).getHash();
     }
 }

--- a/src/test/java/provenj/RunCukesTest.java
+++ b/src/test/java/provenj/RunCukesTest.java
@@ -5,6 +5,6 @@ import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"pretty"})
+@CucumberOptions(plugin = {"pretty"}, features = "src/test/resources/provenj")
 public class RunCukesTest {
 }


### PR DESCRIPTION
[ipfs/java-ipfs-api](https://github.com/ipfs/java-ipfs-api) uses lambdas, which are nice, but are not supported within a library in Android at the moment. Instead I've switched to using [ligi/ipfs-api/kotlin](https://github.com/ligi/ipfs-api-kotlin) after altering it to handle subdirectory add.